### PR TITLE
feat(app): make changes to privacy terms page

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,10 @@
-FROM node:18 as build
+FROM node:20 as build
 WORKDIR /app
 COPY package.json .
 RUN npm install
 COPY . .
 
-FROM node:18
+FROM node:20
 WORKDIR /app
 COPY --from=build /app .
 EXPOSE 3000

--- a/package.json
+++ b/package.json
@@ -3,6 +3,9 @@
   "version": "0.1.0",
   "private": true,
   "dependencies": {
+    "@emotion/react": "^11.11.0",
+    "@emotion/styled": "^11.11.0",
+    "@mui/material": "^5.12.3",
     "@redux-devtools/extension": "^3.2.3",
     "@testing-library/jest-dom": "^5.16.5",
     "@testing-library/react": "^14.0.0",
@@ -80,7 +83,7 @@
     "eslint-plugin-react": "^7.31.10",
     "eslint-plugin-react-hooks": "^4.6.0",
     "husky": ">=8.0.1",
-    "lint-staged": ">=13.0.3",
+    "lint-staged": "^13.2.2",
     "sass": "^1.55.0",
     "vite": "3.2.1"
   },

--- a/src/pages/PrivacyTerms/index.jsx
+++ b/src/pages/PrivacyTerms/index.jsx
@@ -2,7 +2,8 @@
  * Module dependencies.
  */
 
-import { Button } from 'react-bootstrap';
+import './index.scss';
+import { Button } from '@mui/material';
 import React from 'react';
 import { useTranslation } from 'react-i18next';
 
@@ -14,29 +15,29 @@ function PrivacyTerms() {
   const { t } = useTranslation();
 
   return (
-    <center>
-      <div className={'h2'}>
-        <strong>{t('menu.privacy-terms')}</strong>
+    <div className={'terms'}>
+      <div className={'terms__container'}>
+        <div className={'terms__content'}>
+          <h2 className={'terms__heading h2'}>{t('menu.privacy-terms')}</h2>
+          <p className={'terms__paragraph'}>{t('pages.privacy-terms.text1')}</p>
+          <p className={'terms__paragraph'}>{t('pages.privacy-terms.text2')}</p>
+          <p className={'terms__paragraph'}>{t('pages.privacy-terms.delete-local-data-text')}</p>
+          <br />
+        </div>
+        <Button
+          className={'terms__btn'}
+          color={'error'}
+          onClick={() => {
+            localStorage.clear();
+            window.location.reload();
+          }}
+          style={{ textTransform: 'capitalize' }}
+          variant={'contained'}
+        >
+          {t('pages.privacy-terms.delete-local-data-button')}
+        </Button>
       </div>
-      <br />
-      <p>{t('pages.privacy-terms.text1')}</p>
-      <p>{t('pages.privacy-terms.text2')}</p>
-      <br />
-      <br />
-      <p>
-        <strong>{t('pages.privacy-terms.delete-local-data-text')}</strong>
-      </p>
-      <br />
-      <Button
-        onClick={() => {
-          localStorage.clear();
-          window.location.reload();
-        }}
-        variant={'danger'}
-      >
-        {t('pages.privacy-terms.delete-local-data-button')}
-      </Button>
-    </center>
+    </div>
   );
 }
 

--- a/src/pages/PrivacyTerms/index.scss
+++ b/src/pages/PrivacyTerms/index.scss
@@ -1,0 +1,26 @@
+.terms {
+  &__container {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    padding: 0 2rem;
+    margin: 0 auto;
+    max-width: 122rem;
+  }
+
+  &__content {
+    text-align: center;
+  }
+
+  &__heading {
+    font-weight: 700;
+    margin-block: 1rem;
+  }
+
+  &__paragraph {
+    &:last-of-type {
+      margin-top: 2rem;
+      font-weight: 700;
+    }
+  }
+}


### PR DESCRIPTION
Privacy Terms Page: migrate to MUI #39

**package.json**

- add MUI packages

**index.jsx**

- make changes to markup in order to make it more semantic, more structured and add classnames to elements
- replace button for the MUI version and add styles to it 

index.scss

- create css file to add styles to the page